### PR TITLE
Trim leading slash from path for content defined files

### DIFF
--- a/internal/targzip/targz.go
+++ b/internal/targzip/targz.go
@@ -99,7 +99,7 @@ func (t *TarGzip) AddFile(filename string, dest ...string) error {
 // AddFileFromBuffer adds a file from a buffer
 func (t *TarGzip) AddFileFromBuffer(filename string, b []byte) error {
 	hdr := tar.Header{
-		Name:     filename,
+		Name:     strings.Trim(filename, "/"),
 		Size:     int64(len(b)),
 		Mode:     0644,
 		Uid:      0,


### PR DESCRIPTION
Config like this
```
files:
  - dest: /etc/hello
    content: >
      hello world
```
produces incorect .tar.gz due to leading slash in destination file name.
This PR aims to fix it.