### PR TITLE
Let files be owned by root

### DIFF
--- a/internal/targzip/targz.go
+++ b/internal/targzip/targz.go
@@ -82,6 +82,8 @@ func (t *TarGzip) AddFile(filename string, dest ...string) error {
 	hdr.Name = strings.Trim(hdr.Name, "/")
 	hdr.Uid = 0
 	hdr.Gid = 0
+	hdr.Uname = "root"
+	hdr.Gname = "root"
 
 	// write the header to the tarball archive
 	if err := t.writeHeader(hdr); err != nil {


### PR DESCRIPTION
As of the current master, debpkg sets the UID and GID for added files to 0, as expected. The files' original owner *name* is kept as is, though.

On Ubuntu 22.04 (and possibly others), this will result in the file being owned by the *original* owner if the username exists on the target system when installing the package.

This can become a security issue. On a target system with no matching username, binaries owned by root will be installed, and a target with a matching username will install binaries owned by some non-root user, allowing the user to modify system binaries.

This change replaces the original owner and group with "root".

As far as I understand, the Debian Policy Manual says we let all files be owned by root in section 10.9: Permissions and owners.