### PR TITLE
Write maintainer scripts with mode 0755

### DIFF
--- a/control.go
+++ b/control.go
@@ -212,7 +212,7 @@ func (deb *DebPkg) AddControlExtraString(name, s string) error {
 		deb.control.hasCustomConffiles = true
 	}
 	s = strings.Replace(s, "\r\n", "\n", -1)
-	return deb.control.tgz.AddFileFromBuffer(name, []byte(s))
+	return deb.control.tgz.AddFileFromBuffer(name, []byte(s), 0755)
 }
 
 // AddControlExtra allows the advanced user to add custom script to the control.tar.gz Typical usage is
@@ -250,15 +250,15 @@ func (c *control) markConfigFile(dest string) error {
 // config-files
 func (c *control) finalizeControlFile(d *data) error {
 	if !c.hasCustomConffiles {
-		if err := c.tgz.AddFileFromBuffer("conffiles", []byte(c.conffiles)); err != nil {
+		if err := c.tgz.AddFileFromBuffer("conffiles", []byte(c.conffiles), 0); err != nil {
 			return err
 		}
 	}
 	controlFile := []byte(c.String(d.tgz.Written()))
-	if err := c.tgz.AddFileFromBuffer("control", controlFile); err != nil {
+	if err := c.tgz.AddFileFromBuffer("control", controlFile, 0); err != nil {
 		return err
 	}
-	if err := c.tgz.AddFileFromBuffer("md5sums", []byte(d.md5sums)); err != nil {
+	if err := c.tgz.AddFileFromBuffer("md5sums", []byte(d.md5sums), 0); err != nil {
 		return err
 	}
 	return nil

--- a/data.go
+++ b/data.go
@@ -70,7 +70,7 @@ func (d *data) addToMD5sums(md5 []byte, dest string) {
 func (d *data) addFileString(contents, dest string) error {
 	d.addParentDirectories(dest)
 
-	if err := d.tgz.AddFileFromBuffer(dest, []byte(contents)); err != nil {
+	if err := d.tgz.AddFileFromBuffer(dest, []byte(contents), 0); err != nil {
 		return err
 	}
 

--- a/internal/targzip/targz.go
+++ b/internal/targzip/targz.go
@@ -98,12 +98,16 @@ func (t *TarGzip) AddFile(filename string, dest ...string) error {
 	return nil
 }
 
-// AddFileFromBuffer adds a file from a buffer
-func (t *TarGzip) AddFileFromBuffer(filename string, b []byte) error {
+// AddFileFromBuffer adds a file from a buffer. The mode is optional and defaults to 0644.
+func (t *TarGzip) AddFileFromBuffer(filename string, b []byte, mode int64) error {
+	if mode == 0 {
+		mode = 0644
+	}
+
 	hdr := tar.Header{
 		Name:     strings.Trim(filename, "/"),
 		Size:     int64(len(b)),
-		Mode:     0644,
+		Mode:     mode,
 		Uid:      0,
 		Gid:      0,
 		ModTime:  time.Now(),


### PR DESCRIPTION
This PR will set the permission of maintainer scripts to 0755 as suggested by the Debian Policy Manual.

The following control files will be affected: `preinst`, `postinst`, `prerm`, `postrm`.

Please see the following sections of the Debian Policy Manual:
[6.1. Introduction to package maintainer scripts](https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html#introduction-to-package-maintainer-scripts)
[10.9. Permissions and owners](https://www.debian.org/doc/debian-policy/ch-files.html#permissions-and-owners)